### PR TITLE
[FEAT] Handle 47N GB3 data

### DIFF
--- a/fetchAZA/convertAZA.py
+++ b/fetchAZA/convertAZA.py
@@ -18,6 +18,7 @@ def convertAZA(
     water_depth="0",
     keys=["DQZ", "PIES", "INC", "TMP", "KLR"],
     cleanup=True,
+    overwrite=None,
 ):
     """
     Processes and converts AZA data from CSV to netCDF format.
@@ -40,6 +41,13 @@ def convertAZA(
         Longitude of the station.
     water_depth : float
         Water depth at the station.
+    keys : list of str
+        Keys for intermediate files to process.
+    cleanup : bool
+        Whether to delete intermediate files after processing.
+    overwrite : bool, optional
+        If True, overwrite existing files. If False, skip existing files.
+        If None, prompt the user for input.
 
     Returns
     -------
@@ -72,7 +80,7 @@ def convertAZA(
     # Convert the data
     datasets = readers.read_csv_to_xarray(file_path)
     # Save intermediate files
-    writers.save_datasets(datasets, file_path)
+    writers.save_datasets(datasets, file_path, overwrite=overwrite)
     # Process the data
     ds_pressure, ds_AZA = tools.process_datasets(
         data_path, file_root, deploy_date, recovery_date
@@ -105,12 +113,12 @@ def convertAZA(
     output_file = os.path.join(
         data_path, f"{STN}_{deploy_date.replace('-','').replace('/','')}_use.nc"
     )
-    writers.save_dataset(ds_pressure, output_file)
+    writers.save_dataset(ds_pressure, output_file, overwrite=overwrite)
 
     output_file = os.path.join(
-        data_path, f"{STN}_{deploy_date.replace('-','').replace('/','')}_AZA.nc"
+        data_path, f"{STN}_{deploy_date.replace('-','').replace('/','')}_AZAseq.nc"
     )
-    writers.save_dataset(ds_AZA, output_file)
+    writers.save_dataset(ds_AZA, output_file, overwrite=overwrite)
 
     if cleanup:
         # Delete the intermediate files

--- a/fetchAZA/tools.py
+++ b/fetchAZA/tools.py
@@ -195,6 +195,14 @@ def process_datasets(
 
     # Load netCDF interim files
     datasets = readers.load_netcdf_datasets(data_path, file_root, keys)
+    _log.info(f"Loaded {len(datasets)} datasets: {list(datasets.keys())}")
+    for key, ds in datasets.items():
+        record_time_len = len(ds.get("RECORD_TIME", [])) if "RECORD_TIME" in ds else 0
+        _log.info(
+            f"Dataset {key}: {len(ds.variables)} variables, RECORD_TIME length: {record_time_len}"
+        )
+        if record_time_len == 0:
+            _log.warning(f"Dataset {key} has no RECORD_TIME data!")
 
     # Change units to preferred
     for key in datasets:
@@ -203,12 +211,44 @@ def process_datasets(
         ds = timetools.convert_seconds_to_float(ds)
 
     # Assign sampling time for AZA sequence
-    datasets["AZAseq"] = timetools.assign_sample_time(
-        datasets["AZAseq"], pattern=datasets["AZAseq"].attrs["pattern"], adjust_time=15
-    )
+    if "AZAseq" in datasets:
+        _log.info(
+            f"AZAseq dataset found with {len(datasets['AZAseq']['RECORD_TIME'])} records"
+        )
+        _log.info(
+            f"AZAseq pattern: {datasets['AZAseq'].attrs.get('pattern', 'No pattern attribute')}"
+        )
+        datasets["AZAseq"] = timetools.assign_sample_time(
+            datasets["AZAseq"],
+            pattern=datasets["AZAseq"].attrs["pattern"],
+            adjust_time=15,
+        )
+        _log.info(
+            f"AZAseq after time assignment: {len(datasets['AZAseq']['RECORD_TIME'])} records"
+        )
+    else:
+        _log.warning("No AZAseq dataset found in loaded datasets")
 
     # Cut dataset to deployment period
     datasets = timetools.cut_to_deployment(datasets, deploy_date, recovery_date)
+    _log.info("After cutting to deployment period:")
+    for key, ds in datasets.items():
+        record_time_len = len(ds.get("RECORD_TIME", [])) if "RECORD_TIME" in ds else 0
+        _log.info(f"Dataset {key}: RECORD_TIME length: {record_time_len}")
+        if record_time_len == 0:
+            _log.warning(
+                f"Dataset {key} has no data after deployment period filtering!"
+            )
+        if key == "AZAseq":
+            _log.info(f"AZAseq after deployment filtering: {record_time_len} records")
+            if record_time_len > 0:
+                _log.info(
+                    f"AZAseq time range: {ds['RECORD_TIME'].min().values} to {ds['RECORD_TIME'].max().values}"
+                )
+            else:
+                _log.warning(
+                    "AZAseq dataset is empty after deployment period filtering!"
+                )
 
     # Assign attributes to dataset variables using readers.vocab_attrs
     for key in datasets:
@@ -234,6 +274,15 @@ def process_datasets(
 
     time_var = "RECORD_TIME"
     keys_to_combine = ["KLR", "INC", "DQZ", "TMP", "PIES"]
+
+    # Filter keys_to_combine to only include datasets that actually exist
+    available_keys = [key for key in keys_to_combine if key in datasets]
+    if len(available_keys) < len(keys_to_combine):
+        missing_keys = [key for key in keys_to_combine if key not in datasets]
+        _log.warning(
+            f"Some expected datasets are missing: {missing_keys}. Proceeding with available datasets: {available_keys}"
+        )
+        keys_to_combine = available_keys
 
     vars_to_rename = {
         "KLR": {
@@ -293,7 +342,18 @@ def process_datasets(
             print(f"Dataset {key} not included in combined datasets")
 
     # Combine datasets into one
+    _log.info(
+        f"Combining {len(combined_datasets)} datasets: {list(combined_datasets.keys())}"
+    )
+    for key, ds in combined_datasets.items():
+        _log.info(
+            f"Dataset {key}: {len(ds.variables)} variables, RECORD_TIME length: {len(ds.get('RECORD_TIME', []))}"
+        )
+
     combined_dataset = xr.merge(combined_datasets.values(), compat="override")
+    _log.info(
+        f"Combined dataset: {len(combined_dataset.variables)} variables, RECORD_TIME length: {len(combined_dataset.get('RECORD_TIME', []))}"
+    )
     # Assign attributes to combined_dataset from all_attributes
     for key, attrs in all_attributes.items():
         for attr_name, attr_value in attrs.items():
@@ -310,6 +370,13 @@ def process_datasets(
         if any(attr_name == skip for skip in attr_skip):
             del combined_dataset.attrs[attr_name]
     _, med_sr = timetools.calculate_sample_rate(combined_dataset)
+
+    # Check if combined_dataset has any data
+    if len(combined_dataset["RECORD_TIME"]) == 0:
+        _log.error("Combined dataset is empty - no RECORD_TIME data found")
+        raise ValueError(
+            "Combined dataset is empty. No data was loaded from the intermediate netCDF files. Check that the CSV file contains valid data for the specified keys."
+        )
 
     # Create an evenly spaced time grid based on combined_dataset['RECORD_TIME']
     time_start = combined_dataset["RECORD_TIME"].min().values
@@ -363,7 +430,13 @@ def process_datasets(
             ds_AZA.attrs[new_name] = ds_AZA.attrs.pop(old_name)
     if "SERIAL_NUMBER" in ds_AZA.variables:
         snvalue = ds_AZA["SERIAL_NUMBER"].mean().item()
-        ds_AZA.attrs["Serial_Number_Low"] = int(snvalue)
+        if np.isnan(snvalue):
+            _log.warning(
+                "SERIAL_NUMBER contains NaN values, setting Serial_Number_Low to 0"
+            )
+            ds_AZA.attrs["Serial_Number_Low"] = 0
+        else:
+            ds_AZA.attrs["Serial_Number_Low"] = int(snvalue)
         ds_AZA = ds_AZA.drop_vars("SERIAL_NUMBER")
 
     ds_AZA = utilities.set_best_dtype(ds_AZA)

--- a/fetchAZA/writers.py
+++ b/fetchAZA/writers.py
@@ -56,7 +56,7 @@ def delete_netcdf_datasets(
     return deleted_count
 
 
-def save_dataset(ds, output_file="../data/test.nc"):
+def save_dataset(ds, output_file="../data/test.nc", overwrite=None):
     """
     Attempts to save the dataset to a NetCDF file. If a TypeError occurs due to invalid attribute values,
     it converts the invalid attributes to strings and retries the save operation.
@@ -65,6 +65,8 @@ def save_dataset(ds, output_file="../data/test.nc"):
     ----------
     ds (xarray.Dataset): The dataset to be saved.
     output_file (str): The path to the output NetCDF file. Defaults to 'test.nc'.
+    overwrite (bool, optional): If True, overwrite existing files. If False, skip existing files.
+                              If None, prompt the user for input.
 
     Returns
     -------
@@ -74,6 +76,27 @@ def save_dataset(ds, output_file="../data/test.nc"):
     ----
     Based on: https://github.com/pydata/xarray/issues/3743
     """
+    # Check if file exists and handle accordingly
+    if os.path.exists(output_file):
+        if overwrite is None:
+            response = (
+                input(f"File {output_file} already exists. Overwrite? (y/n): ")
+                .lower()
+                .strip()
+            )
+            overwrite = response in ("y", "yes")
+
+        if overwrite:
+            try:
+                os.remove(output_file)
+                _log.info(f"Deleted existing file: {output_file}")
+            except Exception as e:
+                _log.error(f"Failed to delete existing file {output_file}: {e}")
+                return False
+        else:
+            _log.info(f"Skipping save - file already exists: {output_file}")
+            return False
+
     valid_types = (str, int, float, np.float32, np.float64, np.int32, np.int64)
     # More general
     valid_types = (str, Number, np.ndarray, np.number, list, tuple)
@@ -99,6 +122,7 @@ def save_dataset(ds, output_file="../data/test.nc"):
 
     try:
         ds.to_netcdf(output_file)
+        _log.info(f"Successfully saved dataset to: {output_file}")
         return True
     except TypeError as e:
         print(e.__class__.__name__, e)
@@ -111,6 +135,7 @@ def save_dataset(ds, output_file="../data/test.nc"):
                     variable.attrs[k] = str(v)
         try:
             ds.to_netcdf(output_file)  # , format='NETCDF4_CLASSIC'
+            _log.info(f"Successfully saved dataset to: {output_file}")
             return True
         except Exception as e:
             _log.error("Failed to save dataset:", e)
@@ -125,7 +150,7 @@ def save_dataset(ds, output_file="../data/test.nc"):
             return False
 
 
-def save_datasets(data_sets_new, input_fn):
+def save_datasets(data_sets_new, input_fn, overwrite=None):
     """
     Save multiple datasets to NetCDF files with filenames derived from the input filename.
 
@@ -135,6 +160,9 @@ def save_datasets(data_sets_new, input_fn):
         A dictionary where keys are dataset identifiers (e.g., strings) and values are the corresponding datasets to be saved.
     input_fn : str
         The input filename used as a base to generate output filenames.
+    overwrite : bool, optional
+        If True, overwrite existing files. If False, skip existing files.
+        If None, prompt the user for input.
 
     Notes
     -----
@@ -151,6 +179,6 @@ def save_datasets(data_sets_new, input_fn):
         _log.info(f"------------ Saving dataset for key: {key} ------------")
         output_file = os.path.splitext(input_fn)[0] + f"_{key}.nc"
 
-        if not save_dataset(ds, output_file):
+        if not save_dataset(ds, output_file, overwrite=overwrite):
             _log.error(f"Failed to save dataset for key: {key}")
             print(f"Failed to save dataset for key: {key}")


### PR DESCRIPTION
Update to handle data from EPOC GB3 location:

No serial numbers were in the *.csv file, which caused later processing to stumble.

- Better error handling for missing serial numbers
- Do not require PIES data to be available
- Improved writers to allow a prompt to user to overwrite (instead of crashing), but done with optional parameters